### PR TITLE
Update langgraph dependency version to 0.6.0 or above

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.9"
 dependencies = [
-    "langgraph>=0.2.6",
+    "langgraph>=0.6.0",
     "python-dotenv>=1.0.1",
 ]
 


### PR DESCRIPTION
Runtime was added in 0.6.0 so the langgraph dependency version must be dumped as well. I am not totally familiar with pip inner working but somehow it wouldn't upgrade without changing this value, even with the update option `pip install -e . "langgraph-cli[inmem]" -U`.